### PR TITLE
Support multiple strips in one Python program

### DIFF
--- a/examples/dual_animation.py
+++ b/examples/dual_animation.py
@@ -1,0 +1,55 @@
+
+import adafruit_pixelbuf
+import board
+from adafruit_led_animation.animation.rainbow import Rainbow
+from adafruit_led_animation.animation.rainbowchase import RainbowChase
+from adafruit_led_animation.animation.rainbowcomet import RainbowComet
+from adafruit_led_animation.animation.rainbowsparkle import RainbowSparkle
+from adafruit_led_animation.sequence import AnimationSequence
+from adafruit_raspberry_pi5_neopixel_write import neopixel_write
+
+NEOPIXEL1 = board.D13
+NEOPIXEL2 = board.D12
+num_pixels = 96
+
+class Pi5Pixelbuf(adafruit_pixelbuf.PixelBuf):
+    def __init__(self, pin, size, **kwargs):
+        self._pin = pin
+        super().__init__(size=size, **kwargs)
+
+    def _transmit(self, buf):
+        neopixel_write(self._pin, buf)
+
+pixels1 = Pi5Pixelbuf(NEOPIXEL1, num_pixels, auto_write=True, byteorder="BGR")
+pixels2 = Pi5Pixelbuf(NEOPIXEL2, num_pixels, auto_write=True, byteorder="BGR")
+
+def make_animation(pixels):
+    rainbow = Rainbow(pixels, speed=0.02, period=2)
+    rainbow_chase = RainbowChase(pixels, speed=0.02, size=5, spacing=3)
+    rainbow_comet = RainbowComet(pixels, speed=0.02, tail_length=7, bounce=True)
+    rainbow_sparkle = RainbowSparkle(pixels, speed=0.02, num_sparkles=15)
+
+
+    animations = AnimationSequence(
+        rainbow,
+        rainbow_chase,
+        rainbow_comet,
+        rainbow_sparkle,
+        advance_interval=5,
+        auto_clear=True,
+        random_order=True,
+    )
+    return animations
+
+animation1 = make_animation(pixels1)
+animation2 = make_animation(pixels2)
+
+try:
+    while True:
+        animation1.animate()
+        animation2.animate()
+finally:
+    pixels1.fill(0)
+    pixels1.show()
+    pixels2.fill(0)
+    pixels2.show()

--- a/examples/dual_test.py
+++ b/examples/dual_test.py
@@ -1,0 +1,36 @@
+# Test for https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Neopixel/issues/3
+# With the bug NOT fixed, some of the pixels would be corrupted.
+#
+# This corruption wasn't seen (or wasn't seen as much) if the Python program
+# had any sleeps between updates, such as the dual_animation example. Thus,
+# a dedicated reproducer for the bug is desired.
+
+import time
+
+import adafruit_pixelbuf
+import board
+from adafruit_raspberry_pi5_neopixel_write import neopixel_write
+
+NEOPIXEL1 = board.D13
+NEOPIXEL2 = board.D12
+num_pixels = 96
+
+class Pi5Pixelbuf(adafruit_pixelbuf.PixelBuf):
+    def __init__(self, pin, size, **kwargs):
+        self._pin = pin
+        super().__init__(size=size, **kwargs)
+
+    def _transmit(self, buf):
+        neopixel_write(self._pin, buf)
+
+pixels1 = Pi5Pixelbuf(NEOPIXEL1, num_pixels, auto_write=True, byteorder="BGR")
+pixels2 = Pi5Pixelbuf(NEOPIXEL2, num_pixels, auto_write=True, byteorder="BGR")
+
+while True:
+    pixels1.fill(0x1)
+    pixels2.fill(0x100)
+    time.sleep(.1)
+
+    pixels1.fill(0x100)
+    pixels2.fill(0x10000)
+    time.sleep(.1)


### PR DESCRIPTION
Previously, a necessary delay at the end of pixel transmission was not enforced.

I tested on a Pi 5 with two https://www.adafruit.com/product/4310 strips on pins 12 & 13. I also re-tested with the single strip program and it still worked.

Closes: #3